### PR TITLE
fix(core): memory leaks and resource management issues

### DIFF
--- a/src/torchlight/AudioClip.py
+++ b/src/torchlight/AudioClip.py
@@ -78,8 +78,6 @@ class AudioClip:
                         ),
                     )
 
-        del self.audio_player
-
     def OnUpdate(self, old_position: int, new_position: int) -> None:
         delta = new_position - old_position
         self.last_position = new_position

--- a/src/torchlight/ClientProtocol.py
+++ b/src/torchlight/ClientProtocol.py
@@ -22,7 +22,7 @@ class ClientProtocol(Protocol):
         self.buffer += data
 
         chunks = self.buffer.split(b"\0")
-        if data[-1] == b"\0":
+        if data[-1] == 0:
             chunks = chunks[:-1]
             self.buffer = bytearray()
         else:

--- a/src/torchlight/FFmpegAudioPlayer.py
+++ b/src/torchlight/FFmpegAudioPlayer.py
@@ -189,7 +189,7 @@ class FFmpegAudioPlayer:
         self.uri = ""
 
         self.Callback("Stop")
-        del self.callbacks
+        self.callbacks = []
 
         return True
 

--- a/src/torchlight/SourceRCONServer.py
+++ b/src/torchlight/SourceRCONServer.py
@@ -26,6 +26,9 @@ class SourceRCONServer:
         self.logger.info(sys._getframe().f_code.co_name + f" Peer {peer.name} disconnected!")
         self.peers.remove(peer)
 
+    def Close(self) -> None:
+        self._serv_sock.close()
+
     async def _server(self) -> None:
         while True:
             peer_socket: socket.socket
@@ -39,7 +42,7 @@ class SourceRCONServer:
                 self.password,
                 self.torchlight_handler.command_handler,
             )
-            asyncio.Task(self._peer_handler(peer))
+            asyncio.ensure_future(self._peer_handler(peer))
             self.peers.append(peer)
             self.logger.info(sys._getframe().f_code.co_name + f" Peer {peer.name} connected!")
 

--- a/src/torchlight/TorchlightHandler.py
+++ b/src/torchlight/TorchlightHandler.py
@@ -20,7 +20,7 @@ class TorchlightHandler:
 
         self.Init()
 
-        asyncio.ensure_future(self._Connect(), loop=self.loop)
+        asyncio.ensure_future(self._Connect())
 
     async def _Connect(self) -> None:
         # Connect to API
@@ -137,7 +137,7 @@ class TorchlightHandler:
 
         self.Init()
 
-        asyncio.ensure_future(self._Connect(), loop=self.loop)
+        asyncio.ensure_future(self._Connect())
 
     def __del__(self) -> None:
         self.logger.debug("~TorchlightHandler()")

--- a/src/torchlight/cli.py
+++ b/src/torchlight/cli.py
@@ -51,7 +51,7 @@ def cli(config_folder: str) -> None:
         config["TorchRCON"],
         torchlight_handler,
     )
-    asyncio.Task(rcon_server._server())
+    asyncio.ensure_future(rcon_server._server())
 
     # Run!
     event_loop.run_forever()


### PR DESCRIPTION
Several resource management bugs across the async audio pipeline and network layer: dangling attribute deletion, a dead-code branch from a wrong type comparison, and deprecated asyncio APIs.

## Fixes

- **`FFmpegAudioPlayer.Stop()`** — `del self.callbacks` removed the attribute entirely. Concurrent async tasks (`_read_stream`, `_updater`) suspended at `await` points could resume and call `Callback()` post-`Stop()`, raising `AttributeError`. Replaced with `self.callbacks = []` to safely drain references.

- **`AudioClip.OnStop()`** — `del self.audio_player` executed while the player's own `Callback("Stop")` chain was still on the call stack. Fragile and unnecessary; removed.

- **`ClientProtocol.data_received()`** — `data[-1] == b"\0"` is always `False` in Python 3 (bytes indexing returns `int`). The `if` branch was dead code. Fixed to `data[-1] == 0`.

- **`SourceRCONServer._server()` / `cli.py`** — `asyncio.Task(coro)` constructor used directly (deprecated). Replaced with `asyncio.ensure_future()`.

- **`TorchlightHandler`** — `asyncio.ensure_future(..., loop=self.loop)` used the `loop` parameter removed in Python 3.12. Removed.

- **`SourceRCONServer`** — `_serv_sock` was never explicitly closed. Added `Close()` method.

### This PR was made by Copilot Agent